### PR TITLE
Add support for `scatter_add` gradient

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -833,6 +833,21 @@ register_grad(pids.GATHER, _gather_prim_grad)
 
 
 @torchctx
+def _scatter_add_prim_grad(a: TensorProxy, /, index: TensorProxy, value: TensorProxy, dim: int) -> TensorProxy:
+    fwd = prims.scatter_add(a, index, value, dim)
+
+    g = get_grad(fwd)
+    # NOTE The value gradient is only valid when src.shape == index.shape.
+    value_grad = prims.gather(g, index, dim)
+    put_grads((a, value), (g, value_grad))
+
+    return fwd
+
+
+register_grad(pids.SCATTER_ADD, _scatter_add_prim_grad)
+
+
+@torchctx
 def _take_along_axis_prim_grad(a: TensorProxy, index: TensorProxy, dim: int) -> TensorProxy:
     fwd = prims.take_along_axis(a, index, dim)
 

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -4389,51 +4389,35 @@ def scatter_add_sample_generator(op, device, dtype, requires_grad, **kwargs):
     make_source = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
 
     # NOTE The value gradient is only valid when src.shape == index.shape.
-    if requires_grad:
-        for shape_a, dim, shape_b in take_along_axis_cases:
-            canonicalized_dim = dim if dim >= 0 else dim + len(shape_a)
-            a = make(shape_a)
-            b = make_index(shape_b, low=0, high=shape_a[dim])
-            c = make_source(shape_b)
-            yield SampleInput(a, index=b, src=c, dim=dim)
-
-        # a.shape, dim, index.shape
-        scatter_add_cases = (
-            ((4, 5, 3), 0, (3, 2, 3)),
-            ((4, 5, 3), 1, (3, 5, 2)),
-            ((4, 5, 3), 2, (3, 2, 8)),
-        )
-        for shape_a, dim, shape_b in scatter_add_cases:
-            a = make(shape_a)
-            b = make_index(shape_b, low=0, high=shape_a[dim])
-            c = make_source(shape_b)
-            yield SampleInput(a, index=b, src=c, dim=dim)
-    else:
-        for shape_a, dim, shape_b in take_along_axis_cases:
-            canonicalized_dim = dim if dim >= 0 else dim + len(shape_a)
+    # For gradient testing, we use the index shape for the source tensor.
+    for shape_a, dim, shape_b in take_along_axis_cases:
+        canonicalized_dim = dim if dim >= 0 else dim + len(shape_a)
+        if requires_grad:
+            shape_source = shape_b
+        else:
             shape_source = list(shape_a)
             shape_source[canonicalized_dim] = shape_b[canonicalized_dim]
-            a = make(shape_a)
-            b = make_index(shape_b, low=0, high=shape_a[dim])
-            c = make_source(shape_source)
-            yield SampleInput(a, index=b, src=c, dim=dim)
+        a = make(shape_a)
+        b = make_index(shape_b, low=0, high=shape_a[dim])
+        c = make_source(shape_source)
+        yield SampleInput(a, index=b, src=c, dim=dim)
 
-        # Questionable use case. Do we want to support these?!
-        # Note that scatter_add doesn't have the broadcast requirement, it only requires
-        # 1. a.shape[i]      >= index.shape[i] for i != dim
-        # 2. source.shape[i] >= index.shape[i] for all i
-        #
-        # a.shape, dim, index.shape, source.shape
-        scatter_add_cases = (
-            ((4, 5, 3), 0, (3, 2, 3), (4, 3, 9)),
-            ((4, 5, 3), 1, (3, 5, 2), (3, 8, 8)),
-            ((4, 5, 3), 2, (3, 2, 8), (5, 8, 8)),
-        )
-        for shape_a, dim, shape_b, shape_source in scatter_add_cases:
-            a = make(shape_a)
-            b = make_index(shape_b, low=0, high=shape_a[dim])
-            c = make_source(shape_source)
-            yield SampleInput(a, index=b, src=c, dim=dim)
+    # Questionable use case. Do we want to support these?!
+    # Note that scatter_add doesn't have the broadcast requirement, it only requires
+    # 1. a.shape[i]      >= index.shape[i] for i != dim
+    # 2. source.shape[i] >= index.shape[i] for all i
+    #
+    # a.shape, dim, index.shape, source.shape
+    scatter_add_cases = (
+        ((4, 5, 3), 0, (3, 2, 3), (4, 3, 9)),
+        ((4, 5, 3), 1, (3, 5, 2), (3, 8, 8)),
+        ((4, 5, 3), 2, (3, 2, 8), (5, 8, 8)),
+    )
+    for shape_a, dim, shape_b, shape_source in scatter_add_cases:
+        a = make(shape_a)
+        b = make_index(shape_b, low=0, high=shape_a[dim])
+        c = make_source(shape_b if requires_grad else shape_source)
+        yield SampleInput(a, index=b, src=c, dim=dim)
 
 
 scatter_add_opinfo = OpInfo(


### PR DESCRIPTION
This PR adds support for `scatter_add` gradient. Note, the `value` gradient is defined when its shape equals the `index` tensor's shape.

Follow-up for https://github.com/Lightning-AI/lightning-thunder/pull/252