### PR TITLE
Fix `_broadcast_in_dim_prim_grad`

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -701,7 +701,10 @@ def _broadcast_in_dim_prim_grad(
     bcast_dims = tuple(b for i, b in enumerate(broadcast_dimensions) if i not in unit_dims)
     reduce_dims = tuple(s for i, s in enumerate(range(len(shape))) if i not in bcast_dims)
 
-    g = ltorch.sum(g, reduce_dims)
+    # NOTE When the reduce_dims tuple is empty, pytorch reduces all dimensions.
+    # In this case, we do not want to reduce any dimensions, so skip this sum.
+    if len(reduce_dims) > 0:
+        g = ltorch.sum(g, reduce_dims)
 
     # NOTE This must be clang.unsqueeze because torch.unsqueeze, unlike clang.unsqueeze, only accepts an integer
     #   (put another way, torch only allows one unsqueeze at a time)

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -2786,6 +2786,7 @@ def broadcast_in_dim_sample_generator(op, device, dtype, requires_grad, **kwargs
 
     # inshape, outshape, dims
     cases = (
+        ([5], [5], [0]),
         ([2], [2, 2], [0]),
         ([2], [2, 2], [1]),
         ([2], [2, 3], [0]),


### PR DESCRIPTION
When the dim tuple is empty, `torch.sum` reduces all dimensions. However, for the `broadcast_in_dim` gradient function, we do not want to reduce any dimensions.